### PR TITLE
Parallel tf publishing (and some small features)

### DIFF
--- a/include/PointcloudMapper.hpp
+++ b/include/PointcloudMapper.hpp
@@ -56,6 +56,8 @@ namespace slam3d
 		tf2_ros::TransformListener mTfListener;
 		tf2_ros::TransformBroadcaster mTfBroadcaster;
 		geometry_msgs::msg::TransformStamped mDrift;
+		std::mutex mMutex;
+		rclcpp::CallbackGroup::SharedPtr mTfCallbackGroup;
 
 		bool mIsOriginInitialized = false;
 	};

--- a/include/PointcloudMapper.hpp
+++ b/include/PointcloudMapper.hpp
@@ -56,5 +56,7 @@ namespace slam3d
 		tf2_ros::TransformListener mTfListener;
 		tf2_ros::TransformBroadcaster mTfBroadcaster;
 		geometry_msgs::msg::TransformStamped mDrift;
+
+		bool mIsOriginInitialized = false;
 	};
 }

--- a/src/PointcloudMapper.cpp
+++ b/src/PointcloudMapper.cpp
@@ -67,7 +67,7 @@ PointcloudMapper::PointcloudMapper(const rclcpp::NodeOptions & options, const st
 	mScanSubscriber = create_subscription<sensor_msgs::msg::PointCloud2>("scan", 10,
 		std::bind(&PointcloudMapper::scanCallback, this, std::placeholders::_1));
 	
-	mTransformTimer = create_wall_timer(100ms, std::bind(&PointcloudMapper::timerCallback, this));
+	mTransformTimer = rclcpp::create_timer(this, this->get_clock(), 100ms, std::bind(&PointcloudMapper::timerCallback, this));
 	
 	mMapPublisher = create_publisher<sensor_msgs::msg::PointCloud2>("map", 10);
 	

--- a/src/PointcloudMapper.cpp
+++ b/src/PointcloudMapper.cpp
@@ -28,6 +28,7 @@ PointcloudMapper::PointcloudMapper(const rclcpp::NodeOptions & options, const st
 	declare_parameter("map_cloud_resolution", 0.1);
 	declare_parameter("min_translation", 0.1);
 	declare_parameter("min_rotation", 0.1);
+	declare_parameter("automatic_optimize", false);
 
 	mRobotName = get_parameter("robot_name").as_string();
 	mLaserName = get_parameter("laser_name").as_string();
@@ -122,6 +123,10 @@ void PointcloudMapper::scanCallback(const sensor_msgs::msg::PointCloud2::SharedP
 			mPclSensor->linkLastToNeighbors();
 			mGraphPublisher->publishNodes(msg->header.stamp, mMapFrame);
 			mGraphPublisher->publishEdges(mPclSensor->getName(), msg->header.stamp, mMapFrame);
+			if(get_parameter("automatic_optimize").as_bool())
+			{
+				mGraph->optimize();
+			}
 		}
 	}
 	catch(std::exception& e)


### PR DESCRIPTION
With these changes, the composable node can be loaded into a multi-threaded executor. Then, tf transforms are published continuously, to prevent the transforms being timed out while the mapper is busy.

Other features (that could also be introduced in separate PR, please give feedback if preferred):

* The timer callback was using a wall timer. This can cause problems with simulated time, so I adjusted it here.
* I added an optional parameter (default: off, same as previous behavior) to run graph optimization in the scan callback without building the map pointcloud. Seems to work well with my bagfile, but maybe not everyone wants to use this.
* An option to enable to start the map at the origin of the odom frame.

Hope I didn't break any formatting conventions.